### PR TITLE
add getValidator()

### DIFF
--- a/src/Laracasts/Validation/LaravelValidator.php
+++ b/src/Laracasts/Validation/LaravelValidator.php
@@ -29,5 +29,15 @@ class LaravelValidator implements FactoryInterface {
 	{
 		return $this->validator->make($formData, $rules, $messages);
 	}
+	
+	/**
+	 * Retrieve validator object
+	 * 
+	 * @return \Illuminate\Calidation\Factory
+	 */
+	public function getValidator()
+	{
+		return $this->validator;
+	}
 
 }


### PR DESCRIPTION
Add option to get hold of validator object for doing more fancy stuff (i.e. Laravel's ->extend() feature etc.)
Haven't touched the interface as not experienced with other validators so not sure how applicable/useful it would be elsewhere.
