### PR TITLE
Allow for the use of nested rules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,5 +20,5 @@
             "Laracasts\\Validation": "src/"
         }
     },
-    "minimum-stability": "stable"
+    "minimum-stability": "dev"
 }

--- a/composer.json
+++ b/composer.json
@@ -20,5 +20,5 @@
             "Laracasts\\Validation": "src/"
         }
     },
-    "minimum-stability": "dev"
+    "minimum-stability": "stable"
 }

--- a/readme.md
+++ b/readme.md
@@ -103,3 +103,30 @@ Now, just inject this object into your controller or application service, and ca
 ```php
 $this->registrationForm->validate(Input::all());
 ```
+
+## Optional
+
+You can also create a set of nested rules like this:
+
+```php
+	/**
+	 * Validation rules for registering
+	 *
+	 * @var array
+	 */
+	protected $rules = [
+		'store' => [
+			'username' => 'required',
+			'email'    => 'required|unique:users',
+		],
+		'update' => [
+			'username' => 'required',
+		]
+	];
+```
+
+To call the set of rules you want to use, simply set a context on the validator before calling `validate()`
+
+```php
+	$this->registrationForm->setContext('store')->validate(Input::all());
+```

--- a/spec/Laracasts/Validation/FormValidatorContextSpec.php
+++ b/spec/Laracasts/Validation/FormValidatorContextSpec.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace spec\Laracasts\Validation;
+
+use Laracasts\Validation\FactoryInterface;
+use Laracasts\Validation\ValidatorInterface;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class FormValidatorContextSpec extends ObjectBehavior
+{
+	function let(FactoryInterface $validatorFactory)
+	{
+		$this->beAnInstanceOf('spec\Laracasts\Validation\AnotherExampleValidator');
+		$this->beConstructedWith($validatorFactory);
+	}
+
+	function it_allows_setting_of_a_context()
+	{
+		$this->setContext('store');
+
+		$this->getContext()->shouldReturn('store');
+	}
+
+	function it_returns_correct_validation_rules()
+	{
+		$this->setContext('store');
+
+		$this->getValidationRules()->shouldReturn(array('username' => 'required'));
+	}
+
+}
+
+class AnotherExampleValidator extends \Laracasts\Validation\FormValidator {
+	protected $rules = [
+		'store' => ['username' => 'required']
+	];
+}

--- a/src/Laracasts/Validation/FormValidator.php
+++ b/src/Laracasts/Validation/FormValidator.php
@@ -6,6 +6,11 @@ use Laracasts\Validation\ValidatorInterface as ValidatorInstance;
 abstract class FormValidator {
 
 	/**
+	 * @var string
+	 */
+	protected $context;
+
+	/**
 	 * @var ValidatorFactory
 	 */
 	protected $validator;
@@ -35,13 +40,13 @@ abstract class FormValidator {
 	 * @return mixed
 	 * @throws FormValidationException
 	 */
-	public function validate($formData, $context = null)
+	public function validate($formData)
 	{
 		$formData = $this->normalizeFormData($formData);
 
 		$this->validation = $this->validator->make(
 			$formData,
-			$this->getValidationRules($context),
+			$this->getValidationRules(),
 			$this->getValidationMessages()
 		);
 
@@ -56,11 +61,28 @@ abstract class FormValidator {
 	/**
 	 * @return array
 	 */
-	public function getValidationRules($context = null)
+	public function getValidationRules()
 	{
-		if( ! is_null($context) && array_key_exists($context, $this->rules)) return $this->rules[$context];
+		if( ! is_null($this->context) && array_key_exists($this->context, $this->rules)) return $this->rules[$this->context];
 		
 		return $this->rules;
+	}
+
+	/**
+	 * @return FormValidator
+	 */
+	public function setContext($context)
+	{
+		$this->context = $context;
+		return $this;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getContext()
+	{
+		return $this->context;
 	}
 
 	/**

--- a/src/Laracasts/Validation/FormValidator.php
+++ b/src/Laracasts/Validation/FormValidator.php
@@ -35,13 +35,13 @@ abstract class FormValidator {
 	 * @return mixed
 	 * @throws FormValidationException
 	 */
-	public function validate($formData)
+	public function validate($formData, $context = null)
 	{
 		$formData = $this->normalizeFormData($formData);
 
 		$this->validation = $this->validator->make(
 			$formData,
-			$this->getValidationRules(),
+			$this->getValidationRules($context),
 			$this->getValidationMessages()
 		);
 
@@ -56,8 +56,10 @@ abstract class FormValidator {
 	/**
 	 * @return array
 	 */
-	public function getValidationRules()
+	public function getValidationRules($context = null)
 	{
+		if( ! is_null($context) && array_key_exists($context, $this->rules)) return $this->rules[$context];
+		
 		return $this->rules;
 	}
 


### PR DESCRIPTION
Allowing for nested rules and then utilizing those rules by setting a context on the validator allows you to use the same validator class for instances where rules only differ slightly. For example in the case of creating a user vs updating a user.

Tests and Documentation included in PR.
